### PR TITLE
feat: option to skip LDAP TLS verification

### DIFF
--- a/config/crd/bases/awx.ansible.com_awxs.yaml
+++ b/config/crd/bases/awx.ansible.com_awxs.yaml
@@ -1862,6 +1862,10 @@ spec:
               ldap_password_secret:
                 description: Secret where can be found the LDAP bind password
                 type: string
+              ldap_skip_tls_verify:
+                description: Skip TLS verification for LDAP
+                default: false
+                type: boolean
               bundle_cacert_secret:
                 description: Secret where can be found the trusted Certificate Authority Bundle
                 type: string

--- a/config/manifests/bases/awx-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/awx-operator.clusterserviceversion.yaml
@@ -727,6 +727,11 @@ spec:
         x-descriptors:
         - urn:alm:descriptor:com.tectonic.ui:advanced
         - urn:alm:descriptor:io.kubernetes:Secret
+      - displayName: Skip TLS verification for LDAP?
+        path: ldap_skip_tls_verify
+        x-descriptors:
+        - urn:alm:descriptor:com.tectonic.ui:advanced
+        - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
       - displayName: Task Args
         path: task_args
         x-descriptors:

--- a/roles/installer/defaults/main.yml
+++ b/roles/installer/defaults/main.yml
@@ -440,6 +440,9 @@ ldap_cacert_secret: ''
 # Secret to lookup that provides the LDAP bind password
 ldap_password_secret: ''
 
+# Whether or not to skip TLS verification for LDAP
+ldap_skip_tls_verify: false
+
 # Secret to lookup that provides the custom CA trusted bundle
 bundle_cacert_secret: ''
 

--- a/roles/installer/templates/settings/ldap.py.j2
+++ b/roles/installer/templates/settings/ldap.py.j2
@@ -1,6 +1,10 @@
 AUTH_LDAP_GLOBAL_OPTIONS = {
 {% if ldap_cacert_ca_crt %}
+    {% if ldap_skip_tls_verify %}
+    ldap.OPT_X_TLS_REQUIRE_CERT: ldap.OPT_X_TLS_NEVER,
+    {% else %}
     ldap.OPT_X_TLS_REQUIRE_CERT: True,
+    {% endif %}
     ldap.OPT_X_TLS_CACERTFILE: "/etc/openldap/certs/ldap-ca.crt"
 {% endif %}
 }


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

Enable option to skip LDAP TLS verification using `ldap_skip_tls_verify`.

See [AUTH_LDAP_START_TLS](https://django-auth-ldap.readthedocs.io/en/latest/reference.html#auth-ldap-start-tls):

> For example, [ldap.OPT_X_TLS_REQUIRE_CERT](https://www.python-ldap.org/en/latest/reference/ldap.html#ldap.OPT_X_TLS_REQUIRE_CERT) can be set to [ldap.OPT_X_TLS_NEVER](https://www.python-ldap.org/en/latest/reference/ldap.html#ldap.OPT_X_TLS_NEVER) to disable certificate verification, perhaps to allow self-signed certificates.

<!---
If you are fixing an existing issue, please include "fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - New or Enhanced Feature

##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
-->

The option `ldap_skip_tls_verify` defaults to `false` and is only applicable when `ldap_cacert_ca_crt` has been specified.
