### PR TITLE
Make receptor_log_level configurable for mesh ingress pods

### DIFF
--- a/roles/mesh_ingress/defaults/main.yml
+++ b/roles/mesh_ingress/defaults/main.yml
@@ -20,3 +20,6 @@ node_selector: ''
 topology_spread_constraints: ''
 tolerations: ''
 affinity: {}
+
+# receptor default values
+receptor_log_level: debug

--- a/roles/mesh_ingress/tasks/creation.yml
+++ b/roles/mesh_ingress/tasks/creation.yml
@@ -58,6 +58,10 @@
   set_fact:
     _image_pull_policy: "{{ awx_spec.image_pull_policy | default(_image_pull_policy, true) }}"
 
+- name: Set receptor_log_level from AWX spec or default
+  set_fact:
+    receptor_log_level: "{{ awx_spec.receptor_log_level | default(receptor_log_level) }}"
+
 - name: Default ingress_type to Route if OpenShift
   set_fact:
     ingress_type: route

--- a/roles/mesh_ingress/templates/receptor_conf.configmap.yml.j2
+++ b/roles/mesh_ingress/templates/receptor_conf.configmap.yml.j2
@@ -9,7 +9,7 @@ data:
     ---
     - node:
         id: {{ ansible_operator_meta.name }}
-    - log-level: debug
+    - log-level: {{ receptor_log_level }}
     - control-service:
         service: control
     - ws-listener:


### PR DESCRIPTION
##### SUMMARY

Make `receptor_log_level` configurable for mesh ingress pods by inheriting the value from the parent AutomationController CR's `receptor_log_level` field.

Previously, the mesh_ingress role hardcoded `log-level: debug` in the receptor ConfigMap template, causing all mesh ingress pods to emit DEBUG-level logs unconditionally. This flooded logs with routing advertisements and service discovery messages that could not be suppressed through the documented `receptor_log_level` CR field, even when users explicitly set it to `info`, `warning`, or `error`.

The fix follows the existing pattern used in the installer role: the mesh_ingress role now extracts `receptor_log_level` from the parent AWX CR spec (via the existing `awx_spec` lookup) and templates it into the receptor configuration. This ensures mesh ingress and controller pods can use the same log level setting while preserving backward compatibility by defaulting to `debug`.

##### ISSUE TYPE
- Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION

**Root cause:**
- [roles/mesh_ingress/templates/receptor_conf.configmap.yml.j2:12](roles/mesh_ingress/templates/receptor_conf.configmap.yml.j2#L12) hardcoded `- log-level: debug`
- No variable extraction in [roles/mesh_ingress/tasks/creation.yml](roles/mesh_ingress/tasks/creation.yml)
- No default in [roles/mesh_ingress/defaults/main.yml](roles/mesh_ingress/defaults/main.yml)
