### PR TITLE
fix: skip PVC creation when backup PVC already exists

### DIFF
--- a/roles/backup/tasks/init.yml
+++ b/roles/backup/tasks/init.yml
@@ -45,6 +45,13 @@
   set_fact:
     backup_pvc: "{{ backup_pvc | default(_default_backup_pvc, true) }}"
 
+- name: Check if backup PVC already exists
+  k8s_info:
+    name: "{{ backup_pvc }}"
+    kind: PersistentVolumeClaim
+    namespace: "{{ backup_pvc_namespace }}"
+  register: _existing_backup_pvc
+
 - block:
     - name: Create PVC for backup
       k8s:
@@ -61,7 +68,8 @@
             namespace: "{{ backup_pvc_namespace }}"
             ownerReferences: null
   when:
-    - (backup_pvc == '' or backup_pvc is not defined) or (create_backup_pvc | bool)
+    - create_backup_pvc | bool
+    - (_existing_backup_pvc.resources | default([])) | length == 0
 
 - name: Set default postgres image
   set_fact:


### PR DESCRIPTION
## Summary

- Fixes backup failures (422 Forbidden) when `spec.backup_pvc` references a pre-existing PVC whose `accessModes` or `storage` differ from the template defaults.
- Before creating the backup PVC, the role now checks whether it already exists. If it does, creation is skipped entirely — avoiding immutable field patches on Bound claims.
- The previous `when` condition (`(backup_pvc == '' or backup_pvc is not defined) or (create_backup_pvc | bool)`) always evaluated true because `backup_pvc` is resolved on the preceding line. It has been replaced with a two-part guard: `create_backup_pvc | bool` AND the PVC must not already exist.

## Root Cause

The "Create PVC for backup" task unconditionally re-applies `backup_pvc.yml.j2` (hardcoded `ReadWriteOnce`, default `5Gi`) over existing Bound claims. The Kubernetes API rejects the update because `spec.accessModes` and `spec.resources.requests.storage` are immutable after creation — resulting in:

```
422 "spec: Forbidden: spec is immutable after creation"
```

This regression was introduced in AAP 2.6; the 2.4 operator did not exhibit this behavior.

## Fix

After resolving the final PVC name (user-provided or default), a `k8s_info` lookup determines whether the PVC already exists. The create block now only runs when **both**:
1. `create_backup_pvc` is `true` (the default), AND
2. No PVC with that name is found in the target namespace.

Pre-existing PVCs — whether user-provided or left over from a previous backup — are left untouched.

## Test Plan

- [ ] Deploy AWX operator with a pre-existing RWX backup PVC (`spec.backup_pvc: my-pvc`). Verify `AWXBackup` succeeds without 422 errors.
- [ ] Deploy without `spec.backup_pvc` set. Verify a new PVC is auto-created with the default name and the backup completes.
- [ ] Set `create_backup_pvc: false` with a valid pre-existing PVC. Verify backup succeeds.
- [ ] Set `create_backup_pvc: false` with a non-existent PVC name. Verify the play fails early with the existing error message.

Fixes: [AAP-83984](https://redhat.atlassian.net/browse/AAP-83984)

Made with [Cursor](https://cursor.com)