### PR TITLE
fix: preserve backup_dir on finalizer path for clean_backup_on_delete

### DIFF
--- a/roles/backup/tasks/init.yml
+++ b/roles/backup/tasks/init.yml
@@ -97,10 +97,12 @@
 - name: Determine the timestamp for the backup once for all nodes
   set_fact:
     now: '{{ lookup("pipe", "date +%F-%H%M%S") }}'
+  when: not finalizer_run | bool
 
 - name: Set backup directory name
   set_fact:
     backup_dir: "/backups/tower-openshift-backup-{{ now }}"
+  when: not finalizer_run | bool
 
 - name: Create directory for backup
   k8s_exec:
@@ -109,3 +111,4 @@
     container: "{{ ansible_operator_meta.name }}-db-management"
     command: >-
       mkdir -p {{ backup_dir }}
+  when: not finalizer_run | bool


### PR DESCRIPTION
##### SUMMARY
`clean_backup_on_delete: true` stopped removing the backup directory
after CR deletion. The postgres_skip_data refactor (#2120) moved
backup_dir/timestamp setup into init.yml, which finalizer.yml also
runs on CR deletion. set_fact overwrote the block-scoped backup_dir
passed in from CR status, so delete_backup.yml deleted a freshly
created empty directory instead of the real backup.

Guards the three affected tasks with `when: not finalizer_run | bool`,
matching the existing finalizer_run branching in main.yml.

##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change

##### ADDITIONAL INFORMATION
Repro: create an AWXBackup with clean_backup_on_delete: true, wait for
backup success, delete the AWXBackup. Before: backup directory remains
on the PVC. After: directory is removed.
