### PR TITLE
fix: remove unused objects.inv import and fix development.md warnings

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -1,6 +1,6 @@
 # Development Guide
 
-There are development yaml examples in the [`dev/`](../dev) directory and Makefile targets that can be used to build, deploy and test changes made to the awx-operator.
+There are development yaml examples in the [`dev/`](https://github.com/ansible/awx-operator/tree/devel/dev) directory and Makefile targets that can be used to build, deploy and test changes made to the awx-operator.
 
 Run `make help` to see all available targets and options.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,16 @@ docs_dir: docs
 strict: true
 use_directory_urls: false
 
+validation:
+  nav:
+    omitted_files: warn
+    not_found: warn
+    absolute_links: warn
+  links:
+    not_found: warn
+    absolute_links: warn
+    unrecognized_links: warn
+
 theme:
   name: "ansible"
   features:
@@ -85,6 +95,7 @@ nav:
       - troubleshooting/debugging.md
   - Contributors Guide:
       - contributors-guide/contributing.md
+      - development.md
       - contributors-guide/release-process.md
       - contributors-guide/author.md
       - contributors-guide/code-of-conduct.md
@@ -108,9 +119,6 @@ plugins:
             docstring_style: sphinx
             merge_init_into_class: yes
             show_submodules: yes
-          import:
-            - url: https://docs.ansible.com/ansible/latest/objects.inv
-              domains: [py, std]
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## Summary

- Remove the unused `mkdocstrings` inventory import (`objects.inv` from docs.ansible.com) that causes HTTP 429 build failures on both GitHub Actions and Read the Docs due to CloudFlare rate limiting
- Add `development.md` to the nav (Contributors Guide section) to fix "not included in nav" warning
- Replace the broken `../dev` relative link in `development.md` with a GitHub URL

## Why the import removal is safe

The `mkdocstrings` inventory import is entirely vestigial:
- No `src/` directory exists (the handler's `paths: [src]` points to nothing)
- No `:::` mkdocstrings directives exist in any doc page
- No Sphinx cross-reference syntax (`:py:`, `:func:`, `:class:`, etc.) appears anywhere in the docs
- The `mkdocstrings` plugin itself remains installed (pulled in by `mkdocs-ansible`) but does nothing without directives


##### ISSUE TYPE
 - Bug, Docs Fix or other nominal change
 
## Test plan

- [x] CI docs build passes (`nox -s build` with `--strict`)
- [x] Read the Docs build passes
- [x] No `development.md` warnings in build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)