### PR TITLE
ci: update GitHub Actions to latest versions (SHA-pinned)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,9 +19,9 @@ jobs:
       DOCKER_API_VERSION: "1.44"
       DEBUG_OUTPUT_DIR: /tmp/awx_operator_molecule_test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.11"
 
@@ -46,7 +46,7 @@ jobs:
 
       - name: Upload artifacts for failed tests if Run Molecule fails
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: awx_operator_molecule_test
           path: ${{ env.DEBUG_OUTPUT_DIR }}
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Check no_log statements
         run: |

--- a/.github/workflows/devel.yaml
+++ b/.github/workflows/devel.yaml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Push devel image
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Fail if QUAY_REGISTRY not set
         run: |
@@ -21,7 +21,7 @@ jobs:
           fi
 
       - name: Log into registry ghcr.io
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567    # v3.3.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f    # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -29,7 +29,7 @@ jobs:
 
 
       - name: Log into registry quay.io
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567    # v3.3.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f    # v4.6.0
         with:
           registry: ${{ vars.QUAY_REGISTRY }}
           username: ${{ secrets.QUAY_USER }}

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Push devel image
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0  # needed so that git describe --tag works
 

--- a/.github/workflows/label_issue.yml
+++ b/.github/workflows/label_issue.yml
@@ -26,12 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Label Issue - Community
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       - name: Install python requests
         run: pip install requests
       - name: Check if user is a member of Ansible org
-        uses: jannekem/run-python-script-action@v1
+        uses: jannekem/run-python-script-action@9d8e2e0878d575fb6073277f38ce3f10ebf4f059 # v1.8
         id: check_user
         with:
           script: |

--- a/.github/workflows/label_pr.yml
+++ b/.github/workflows/label_pr.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     name: Label PR - Community
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
 
       - name: Create a virtual environment
         run: python3 -m venv venv
@@ -25,7 +25,7 @@ jobs:
           pip3 install requests
 
       - name: Check if user is a member of Ansible org
-        uses: jannekem/run-python-script-action@v1
+        uses: jannekem/run-python-script-action@9d8e2e0878d575fb6073277f38ce3f10ebf4f059 # v1.8
         id: check_user
         with:
           script: |

--- a/.github/workflows/promote.yaml
+++ b/.github/workflows/promote.yaml
@@ -37,13 +37,13 @@ jobs:
             exit 1
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           depth: 0
 
 
       - name: Log into registry ghcr.io
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567    # v3.3.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f    # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -51,7 +51,7 @@ jobs:
 
 
       - name: Log into registry quay.io
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567    # v3.3.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f    # v4.6.0
         with:
           registry: ${{ env.QUAY_REGISTRY }}
           username: ${{ secrets.QUAY_USER }}

--- a/.github/workflows/reusable-nox.yml
+++ b/.github/workflows/reusable-nox.yml
@@ -16,9 +16,9 @@ jobs:
         name: "Run nox ${{ matrix.session }} session"
         steps:
         - name: Check out repo
-          uses: actions/checkout@v4
+          uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         - name: Setup nox
-          uses: wntrblm/nox@2024.04.15
+          uses: wntrblm/nox@903fd97f0c3e19a39c3e0847072b652639044d30 # v0.19.1
           with:
               python-versions: "${{ matrix.python-versions }}"
         - name: "Run nox -s ${{ matrix.session }}"

--- a/.github/workflows/stage.yml
+++ b/.github/workflows/stage.yml
@@ -38,7 +38,7 @@ jobs:
           exit 0
 
       - name: Checkout awx-operator
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ${{ github.repository_owner }}/awx-operator
           path: awx-operator
@@ -48,7 +48,7 @@ jobs:
           python3 -m pip install docker
 
       - name: Log into registry ghcr.io
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567    # v3.3.0
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f    # v4.6.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -75,7 +75,7 @@ jobs:
 
       - name: Create Draft Release
         id: create_release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1.1.4
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
## Summary

Update all GitHub Actions to their latest versions with full commit SHA pinning for supply chain security.

Updated via `npx actions-up --yes --include-branches --min-age 3` (default `--style sha`).