### PR TITLE
PoC: trigger reconcile on PG secret rotation via label-selector watch

### DIFF
--- a/playbooks/pg_secret_rotated.yml
+++ b/playbooks/pg_secret_rotated.yml
@@ -1,0 +1,57 @@
+---
+# Triggered by the "kind: Secret" watch entry in watches.yaml whenever a
+# secret carrying the awx.ansible.com/owner-name label changes.
+# ansible_operator_meta here refers to the Secret itself (the primary
+# resource of this watch entry), not an AWX CR. The label's value names the
+# owning CR directly (stamped in postgres_secret.yaml.j2 and self-healed
+# every reconcile in database_configuration.yml, regardless of whether the
+# secret is operator-managed or externally supplied), so there's no need to
+# enumerate every AWX in the namespace or guess by naming convention - just
+# read it and nudge that CR into a real reconcile. The actual
+# credentials.py re-render already happens correctly in the installer
+# role, it just never got triggered.
+- hosts: localhost
+  gather_facts: false
+  collections:
+    - kubernetes.core
+  tasks:
+    - name: Read the triggering PostgreSQL configuration secret
+      k8s_info:
+        kind: Secret
+        name: "{{ ansible_operator_meta.name }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
+      register: _triggering_secret
+
+    - name: Determine the owning AWX from the secret's label
+      set_fact:
+        _owner_name: >-
+          {{ _triggering_secret.resources[0].metadata.labels['awx.ansible.com/owner-name']
+             | default('') }}
+
+    - name: Confirm the owning AWX still exists
+      k8s_info:
+        api_version: awx.ansible.com/v1beta1
+        kind: AWX
+        name: "{{ _owner_name }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
+      register: _owner
+      when: _owner_name | length > 0
+
+    - name: Force a reconcile of the owning AWX
+      k8s:
+        kind: AWX
+        api_version: awx.ansible.com/v1beta1
+        name: "{{ _owner_name }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
+        definition:
+          metadata:
+            annotations:
+              # Value only needs to change to trigger a reconcile (see
+              # watchAnnotationsChanges: true on the AWX watch entry) - the
+              # secret's own resourceVersion is a convenient,
+              # always-changing value to use.
+              awx.ansible.com/pg-secret-resource-version: >-
+                {{ _triggering_secret.resources[0].metadata.resourceVersion }}
+      when:
+        - _owner_name | length > 0
+        - _owner.resources | default([]) | length > 0

--- a/roles/installer/tasks/database_configuration.yml
+++ b/roles/installer/tasks/database_configuration.yml
@@ -100,6 +100,26 @@
   set_fact:
     __postgres_configuration_secret: "{{ pg_config['resources'][0]['metadata']['name'] }}"
 
+# Runs unconditionally (not just for the operator-generated secret above) so
+# rotation-detection also works for an externally supplied
+# postgres_configuration_secret (BYO database, or a secret populated by
+# something like Vault Secrets Operator) - the label is what the "kind:
+# Secret" watch entry in watches.yaml selects on. apply: true only merges
+# metadata.labels here, so this never touches the secret's actual data even
+# when the secret is owned/managed by something else.
+- name: Ensure the resolved PostgreSQL secret carries the reconcile-watch label
+  k8s:
+    apply: true
+    definition:
+      apiVersion: v1
+      kind: Secret
+      metadata:
+        name: "{{ __postgres_configuration_secret }}"
+        namespace: "{{ ansible_operator_meta.namespace }}"
+        labels:
+          awx.ansible.com/owner-name: "{{ ansible_operator_meta.name }}"
+  no_log: "{{ no_log }}"
+
 - name: Store Database Configuration
   set_fact:
     awx_postgres_user: "{{ pg_config['resources'][0]['data']['username'] | b64decode }}"

--- a/roles/installer/templates/secrets/postgres_secret.yaml.j2
+++ b/roles/installer/templates/secrets/postgres_secret.yaml.j2
@@ -7,6 +7,7 @@ metadata:
   namespace: '{{ ansible_operator_meta.namespace }}'
   labels:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
+    awx.ansible.com/owner-name: '{{ ansible_operator_meta.name }}'
 stringData:
   password: '{{ lookup('password', '/dev/null length=32 chars=ascii_letters,digits') }}'
   username: '{{ database_username }}'

--- a/roles/restore/templates/secrets.yml.j2
+++ b/roles/restore/templates/secrets.yml.j2
@@ -7,6 +7,19 @@ metadata:
   namespace: '{{ ansible_operator_meta.namespace }}'
   labels:
     {{ lookup("template", "../common/templates/labels/common.yaml.j2") | indent(width=4) | trim }}
+{% if secret == 'postgresConfigurationSecret' %}
+    # Explicitly unset (not just omitted) so this restore-time apply removes
+    # the label if it survived from a pre-restore copy of this secret,
+    # rather than merge-preserving it. Prevents the "kind: Secret" watch in
+    # watches.yaml from firing on this restore's own write and triggering a
+    # concurrent AWX reconcile while database.yml's postgres
+    # upgrade/migration tasks may still be running for this restore
+    # (roles/installer/tasks/install.yml's restore-complete gate sits after
+    # those tasks, not before them). The normal post-restore reconcile
+    # reasserts this label once restoreComplete is set (see
+    # roles/installer/tasks/database_configuration.yml).
+    awx.ansible.com/owner-name: null
+{% endif %}
 type: '{{ secrets[secret]['type'] }}'
 stringData:
 {% for key, value in secrets[secret]['data'].items() %}

--- a/watches.yaml
+++ b/watches.yaml
@@ -5,6 +5,35 @@
   kind: AWX
   playbook: playbooks/awx.yml
   snakeCaseParameters: False
+  # Metadata-only changes (e.g. the annotation patched by the PG secret watch
+  # entry below) don't bump metadata.generation, so without this the primary
+  # watch on AWX ignores them and no reconcile is triggered.
+  watchAnnotationsChanges: true
+
+# The PG configuration secret is deliberately never given an ownerReference
+# (see roles/installer/tasks/cleanup.yml, which actively strips one off if
+# present) so that it survives CR deletion. That means it can't use
+# ansible-operator's ownerReference-based dependent-resource watch to trigger
+# a reconcile on rotation (e.g. by Vault/VSO). This selector-based watch is
+# an independent mechanism: it matches on label, not ownership, so rotating
+# the secret's data (in place, by whatever manages it) still triggers a
+# reconcile without ever granting it an ownerReference.
+#
+# One watch entry covers every AWX instance in the namespace: the label's
+# key is fixed but its value is the owning CR's own name (set in
+# postgres_secret.yaml.j2 / database_configuration.yml), so "Exists"
+# matches any instance's secret without the entries colliding -
+# pg_secret_rotated.yml reads the value to know which CR to reconcile.
+- version: v1
+  group: ""
+  kind: Secret
+  selector:
+    matchExpressions:
+      - key: awx.ansible.com/owner-name
+        operator: Exists
+  playbook: playbooks/pg_secret_rotated.yml
+  manageStatus: false
+  watchDependentResources: false
 
 - version: v1beta1
   group: awx.ansible.com


### PR DESCRIPTION
## Summary

Proof of concept for discussion — not a finished patch. Rotating the Controller/AWX PostgreSQL configuration secret externally (e.g. via Vault Secrets Operator) never triggers a reconcile today, so `credentials.py` can go stale indefinitely. Root cause: that secret is deliberately never given an `ownerReference` (`cleanup.yml` actively strips one if present, so it survives CR deletion), and ansible-operator's dependent-resource watch requires one to fire.

This PR adds an independent, label-selector-based watch on the secret instead of relying on ownership:

- `watches.yaml`: new `kind: Secret` watch entry with a `matchExpressions: Exists` selector, plus `watchAnnotationsChanges: true` on the primary `AWX` entry.
- `playbooks/pg_secret_rotated.yml` (new): reads the owning `AWX`'s name directly off the secret's label and patches an annotation on it to force a real reconcile.
- `roles/installer/tasks/database_configuration.yml`: unconditionally (labels-only merge, never touches secret data) applies the watch label to whatever secret is actually resolved, so this also covers an externally supplied `postgres_configuration_secret` (BYO database, or a secret populated by VSO before the operator ever runs) — not just the case where the operator generates the secret itself.
- `roles/installer/templates/secrets/postgres_secret.yaml.j2`: the label's value is the owning CR's own name rather than a fixed constant, so one static watch entry correctly covers multiple `AWX` instances in the same namespace.
- `roles/restore/templates/secrets.yml.j2`: explicitly nulls the label when restoring the PG secret. `restore/tasks/main.yml` applies the restored secret before `deploy_awx.yml`/`postgres.yml` run, and `install.yml`'s "wait for restore to complete" gate sits after `database.yml`'s postgres upgrade/migration tasks rather than before them — so on an in-place restore, letting the label survive would let restore's own write retrigger this watch and force a concurrent reconcile mid-restore. The normal post-restore reconcile reasserts the label once `restoreComplete` is set.

The secret still carries no `ownerReference` throughout and never enters Kubernetes' garbage-collection graph.

## Validation

Before writing this patch, validated the underlying ansible-operator mechanism empirically against a live OpenShift cluster with the pinned `ansible-operator` binary:
- A `selector`-filtered watch on a bare `kind: Secret` (no CRD) registers and runs cleanly.
- It correctly matches on label and fires on real data changes (confirmed via `resourceVersion` correlation), not just on a polling interval.
- The secret's `ownerReferences` stayed empty throughout.

## Open questions for reviewers

- Is `matchExpressions`/`selector` on a bare non-CRD `kind: Secret` watch entry an intentional, supported usage of ansible-operator, or is this leaning on undocumented behavior we shouldn't rely on?
- `install.yml`'s "wait for restore to complete" gate sits after `database.yml`'s DB-mutating tasks rather than before them — a pre-existing gap independent of this PR, but worth a second set of eyes given this PR's restore-window fix is built around working around it rather than fixing it directly.
- No tests included yet — wanted early feedback on the approach before investing in molecule coverage.

## Test plan

- [ ] Add molecule/integration coverage for the new watch + playbook
- [ ] Verify against a real Vault Secrets Operator-managed secret, not just a manually rotated one
- [ ] Confirm behavior with multiple `AWX` instances in one namespace