### PR TITLE
Deliver PostgreSQL credentials via live secretKeyRef env vars

### DIFF
--- a/roles/installer/templates/deployments/task.yaml.j2
+++ b/roles/installer/templates/deployments/task.yaml.j2
@@ -35,6 +35,7 @@ spec:
         checksum-{{ template | replace('/', '-') }}: "{{ lookup('template', template + '.yaml.j2') | sha1 }}"
 {% endfor %}
 {% for secret in [
+    "pg_config",
     "bundle_cacert",
     "route_tls",
     "ldap_cacert",
@@ -100,6 +101,32 @@ spec:
           image: '{{ _image }}'
           imagePullPolicy: '{{ image_pull_policy }}'
           resources: {{ init_container_resource_requirements }}
+          env:
+            - name: AWX_DATABASES__default__HOST
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ __postgres_configuration_secret }}"
+                  key: host
+            - name: AWX_DATABASES__default__PORT
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ __postgres_configuration_secret }}"
+                  key: port
+            - name: AWX_DATABASES__default__NAME
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ __postgres_configuration_secret }}"
+                  key: database
+            - name: AWX_DATABASES__default__USER
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ __postgres_configuration_secret }}"
+                  key: username
+            - name: AWX_DATABASES__default__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ __postgres_configuration_secret }}"
+                  key: password
           command:
             - /bin/sh
             - -c
@@ -335,6 +362,31 @@ spec:
               value: "/etc/supervisord_task.conf"
             - name: AWX_SKIP_MIGRATIONS
               value: "1"
+            - name: AWX_DATABASES__default__HOST
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ __postgres_configuration_secret }}"
+                  key: host
+            - name: AWX_DATABASES__default__PORT
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ __postgres_configuration_secret }}"
+                  key: port
+            - name: AWX_DATABASES__default__NAME
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ __postgres_configuration_secret }}"
+                  key: database
+            - name: AWX_DATABASES__default__USER
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ __postgres_configuration_secret }}"
+                  key: username
+            - name: AWX_DATABASES__default__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ __postgres_configuration_secret }}"
+                  key: password
             - name: MY_POD_UID
               valueFrom:
                 fieldRef:

--- a/roles/installer/templates/deployments/web.yaml.j2
+++ b/roles/installer/templates/deployments/web.yaml.j2
@@ -38,6 +38,7 @@ spec:
         checksum-configmaps-redirect-page.configmap.html: "{{ lookup('template', 'configmaps/redirect-page.configmap.html.j2') | sha1 }}"
 {% endif %}
 {% for secret in [
+    "pg_config",
     "bundle_cacert",
     "route_tls",
     "ldap_cacert",
@@ -286,6 +287,31 @@ spec:
               value: "web"
             - name: SUPERVISOR_CONFIG_PATH
               value: "/etc/supervisord_web.conf"
+            - name: AWX_DATABASES__default__HOST
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ __postgres_configuration_secret }}"
+                  key: host
+            - name: AWX_DATABASES__default__PORT
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ __postgres_configuration_secret }}"
+                  key: port
+            - name: AWX_DATABASES__default__NAME
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ __postgres_configuration_secret }}"
+                  key: database
+            - name: AWX_DATABASES__default__USER
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ __postgres_configuration_secret }}"
+                  key: username
+            - name: AWX_DATABASES__default__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: "{{ __postgres_configuration_secret }}"
+                  key: password
             - name: MY_POD_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/roles/installer/templates/settings/credentials.py.j2
+++ b/roles/installer/templates/settings/credentials.py.j2
@@ -1,12 +1,14 @@
+# NAME/USER/PASSWORD/HOST/PORT are intentionally not set here - they're
+# delivered as AWX_DATABASES__default__* environment variables (secretKeyRef
+# against the postgres-configuration secret) on the task/web/init-database
+# containers instead, so there's a single source of truth for the live
+# connection values and a plain pod restart (no operator reconcile required)
+# is sufficient to pick up a rotated password. See checksum-secret-pg_config
+# in the Deployment templates for the reconcile-triggered rollout path.
 DATABASES = {
     'default': {
         'ATOMIC_REQUESTS': True,
         'ENGINE': 'awx.main.db.profiled_pg',
-        'NAME': "{{ awx_postgres_database }}",
-        'USER': "{{ awx_postgres_user }}",
-        'PASSWORD': "{{ awx_postgres_pass }}",
-        'HOST': '{{ awx_postgres_host }}',
-        'PORT': "{{ awx_postgres_port }}",
         'OPTIONS': { 'sslmode': '{{ awx_postgres_sslmode }}',
 {% if awx_postgres_sslmode in ['verify-ca', 'verify-full'] %}
                      'sslrootcert': '{{ ca_trust_bundle }}',


### PR DESCRIPTION
## Summary

Separate, standalone fix from #2141 (the `watches.yaml` reconcile-trigger PoC) — this PR does not touch `watches.yaml` at all. Whether/how to add an automatic reconcile trigger on PG secret rotation is being assessed separately; this PR is scoped to just making a manual/external restart (e.g. VSO's `rolloutRestartTargets`) actually work.

**Problem:** Controller bakes the PostgreSQL password into a literal string in the rendered `credentials.py` settings file, mounted into the task/web pods. That file is only re-rendered when the operator reconciles. If the PG secret is rotated externally (e.g. by Vault Secrets Operator) with no reconcile in between, running pods are left with a stale password indefinitely — and restarting the pod doesn't help, since it just re-mounts the same stale file. EDA, Ansible Lightspeed, and Gateway all avoid this class of bug by delivering DB credentials as live env vars instead of a rendered file.

**Fix:**
- `task.yaml.j2` (`init-database` init container and the `task` container) and `web.yaml.j2` (the `web` container) now also set `AWX_DATABASES__default__HOST/PORT/NAME/USER/PASSWORD` via `secretKeyRef` directly against the postgres-configuration secret.
- `credentials.py.j2` no longer sets `NAME`/`USER`/`PASSWORD`/`HOST`/`PORT` — only `ENGINE` and `OPTIONS` (sslmode/sslrootcert/target_session_attrs) remain, since those have no live env var equivalent. This makes the K8s Secret + these env vars the single source of truth for connection values, rather than duplicating the password into a second rendered Secret's file content (also a small security/hygiene win — one fewer place the plaintext password is materialized at rest).
- Added a `checksum-secret-pg_config` pod-template annotation, mirroring the existing `checksum-secret-{bundle_cacert,route_tls,...}` pattern already used in these same templates (and matching `aap-gateway-operator`'s `checksum-secret-gateway_pg_config` for its own PG secret), reusing the already-registered `pg_config` fact from `database_configuration.yml`. This keeps a reconcile-triggered rollout path working even though `credentials.py`'s content no longer varies with the DB password.

**Net effect:** a plain external pod restart (VSO's `rolloutRestartTargets`, or a manual rollout restart) is now sufficient on its own to pick up a rotated PG password — no operator reconcile required — matching EDA/Lightspeed/Gateway's story.

## Why no `ansible/awx` application changes are needed

AWX's settings loader (`django-ansible-base`'s `factory()`/`load_envvars()`) already uses Dynaconf with an `AWX_` env var prefix, and `load_envvars()` runs last, overriding everything loaded before it. Verified empirically against the actual factory call signature used in `awx/settings/__init__.py` (no explicit `merge_enabled` kwarg) that the `__`-nested-key env var syntax deep-merges into existing dict settings and **adds missing keys**, not just overrides ones already present:

```
base credentials.py-equivalent: DATABASES.default = {ENGINE: ..., OPTIONS: {...}}   # no HOST/USER/PASSWORD
env vars: AWX_DATABASES__default__PASSWORD, __HOST, ...

result: {ENGINE: ..., OPTIONS: {...}, PASSWORD: '...', HOST: '...'}
```

This is the same mechanism already in production use by `automation-metrics-operator` (`METRICS_SERVICE_DATABASES__default__PASSWORD`).

## Upgrades / compatibility

- No secret schema change — `host`/`port`/`database`/`username`/`password` are the exact keys `database_configuration.yml` has always required from any `postgres_configuration_secret`, generated or custom/external (VSO-managed included). Nothing new is required of external secrets.
- Existing installs will see one rolling restart on the first reconcile after upgrading (the Deployment pod template gains new env vars — a genuine spec diff, so Kubernetes rolls the pods regardless of the checksum mechanism). This is a normal one-time operator-upgrade restart, not a data migration.
- `task_extra_env`/`web_extra_env` (customer-supplied raw env blocks) render after these new vars in the container spec, so last-one-wins semantics mean a customer already setting `AWX_DATABASES__default__PASSWORD` via `task_extra_env` would override ours — noted as an edge case, not treated as a conflict to guard against.
- Traced `migrate_data.yml`/`upgrade_postgres.yml` (backup/restore and PG-version-upgrade paths) — both source the password from the Ansible fact (`awx_postgres_pass`) directly, not by parsing the rendered `credentials.py` file, so removing the literal from the file doesn't affect them.

## Open item for reviewers

Haven't verified whether anything in the AWX container image itself (entrypoint scripts, `awx-manage` diagnostics, backup/restore tooling) parses `/etc/tower/conf.d/credentials.py`'s raw text for the DB password directly instead of going through Django's resolved `settings.DATABASES`. Everything traced on the operator side goes through the Ansible fact or Django settings, not the raw file, so I'd expect this to be clean — but it's a real test to run, not something confirmed by static review of this repo alone.

## Test plan

- [ ] Deploy, rotate the PG secret's password directly (no CR spec change), confirm task/web pods keep working with no operator reconcile
- [ ] Confirm a plain `kubectl rollout restart` (simulating VSO's `rolloutRestartTargets`) picks up the new password with zero operator involvement
- [ ] Confirm upgrade from a pre-this-change operator version triggers exactly one rolling restart and comes up healthy
- [ ] Confirm external/custom `postgres_configuration_secret` (not operator-generated) works identically
- [ ] Verify no AWX container image script reads `credentials.py`'s raw DB fields directly